### PR TITLE
"dig" -> "listen to", "provocateury" -> "provocatory"

### DIFF
--- a/src/epub/text/chapter-7.xhtml
+++ b/src/epub/text/chapter-7.xhtml
@@ -247,7 +247,7 @@
 				<p>“To the Population of Petrograd!</p>
 				<p>“Comrades, workers, soldiers and citizens of revolutionary Petrograd!</p>
 				<p>“The Bolsheviki, while appealing for peace at the front, are inciting to civil war in the rear.</p>
-				<p>“Do not dig their provocateury appeals!</p>
+				<p>“Do not listen to their provocatory appeals!</p>
 				<p>“Do not dig trenches!</p>
 				<p>“Down with the traitorous barricades!</p>
 				<p>“Lay down your arms!</p>


### PR DESCRIPTION
"Do not dig" mistakenly repeated from the line below, and provocateury kind of makes sense but is not the original word in the print version.

https://babel.hathitrust.org/cgi/pt?id=wu.89048868350&view=1up&seq=221&q1=do%20not%20dig