### PR TITLE
[Editorial] "aver" -> "over"

### DIFF
--- a/src/epub/text/chapter-9.xhtml
+++ b/src/epub/text/chapter-9.xhtml
@@ -28,7 +28,7 @@
 				<footer>
 					<p>Signed,</p>
 					<p>
-						<i>Commander in Chief aver all Forces acting against the Counterrevolutionary Troops of Kerensky,</i>
+						<i>Commander in Chief over all Forces acting against the Counterrevolutionary Troops of Kerensky,</i>
 					</p>
 					<p>Lieutenant-Colonel <span epub:type="z3998:signature">Muraviov</span>.</p>
 				</footer>


### PR DESCRIPTION
This appears to be a mistake in the original print:

https://babel.hathitrust.org/cgi/pt?id=wu.89048868350&view=1up&seq=248&q1=commander%20in%20chief