### PR TITLE
Unsure, but this might be part of the blockquote

### DIFF
--- a/src/epub/text/chapter-8.xhtml
+++ b/src/epub/text/chapter-8.xhtml
@@ -48,10 +48,8 @@
 			</blockquote>
 			<p>On the walls a vainglorious announcement of the <i xml:lang="ru-Latn">Vikzhel</i>, threatening to strike if both sides did not compromise:</p>
 			<blockquote>
-				<p>“The conquerors of these riots, the saviours of the wreck of our country, these will be neither the Bolsheviki, nor the Committee for Salvation, nor the troops of Kerensky⁠—but we, the Union of Railwaymen⁠ ⁠…”</p>
-			</blockquote>
-			<p>Red Guards are incapable of handling a complicated business like the railways; as for the Provisional Government, it has shown itself incapable of holding the power⁠ ⁠…</p>
-			<blockquote>
+				<p>“The conquerors of these riots, the saviours of the wreck of our country, these will be neither the Bolsheviki, nor the Committee for Salvation, nor the troops of Kerensky⁠—but we, the Union of Railwaymen⁠ ⁠…</p>
+				<p>“Red Guards are incapable of handling a complicated business like the railways; as for the Provisional Government, it has shown itself incapable of holding the power⁠ ⁠…</p>
 				<p>“We refuse to lend our services to any party which does not act by authority of⁠ ⁠… a Government based on the confidence of all the democracy.⁠ ⁠…”</p>
 			</blockquote>
 			<p>Smolny thrilled with the boundless vitality of inexhaustible humanity in action.</p>


### PR DESCRIPTION
I marked this as a potential error while reading, but even after consulting the scans I'm not 100% certain that it's wrong.  And I'm not sure how to prove it either way unless someone who reads russian can find an image or transcription of the original announcement.

In the scans, the center paragraph does seem to be in slightly larger type, and have spacing before and after it that implies it's not part of the quote but not sure if that's just random variation and/or a printing error. Potentially the spacing just indicates that 3 seperate excerpts of the original are being presented.

https://babel.hathitrust.org/cgi/pt?id=wu.89048868350&view=1up&seq=230&q1=union%20of%20Railwaymen

As far as I can tell, either the author quotes twice from the same announcement, and injects his own comment between, or all three paragraphs are from the same announcement. And if it isn't part of the quote then it reads like the author is paraphrasing the opinion of the writers of the announcement rather than offering his own opinion so it's ambigous to me which is correct. But thought I'd flag it in case anyone else can confirm either way.