### PR TITLE
[Editorial] Perograd -> Petrograd

### DIFF
--- a/src/epub/text/chapter-9.xhtml
+++ b/src/epub/text/chapter-9.xhtml
@@ -115,7 +115,7 @@
 			<figure class="full-page" id="illustration-9">
 				<img alt="A facsimile of a government certificate, with stamps and signatures." src="../images/illustration-9.svg" epub:type="se:image.color-depth.black-on-transparent"/>
 				<figcaption>
-					<p>Order given me at Staff headquarters by command of the Council of People’s Commissars, to transmit the first despatch out of Perograd after the November Revolution, over the Government wires to America.</p>
+					<p>Order given me at Staff headquarters by command of the Council of People’s Commissars, to transmit the first despatch out of Petrograd after the November Revolution, over the Government wires to America.</p>
 					<p>(Translation)</p>
 					<blockquote class="pass">
 						<header>


### PR DESCRIPTION
Appears to be a printing error:

https://babel.hathitrust.org/cgi/pt?id=wu.89048868350&view=1up&seq=254&q1=perograd